### PR TITLE
fix: resolve duplicate permalink in Frostgrave lore

### DIFF
--- a/projects/frostgrave-lore/warbandone.md
+++ b/projects/frostgrave-lore/warbandone.md
@@ -3,7 +3,7 @@
 layout: page
 title: Starting Sorcerer
 subtitle: Keldor of Darrik
-permalink: /projects/frostgrave/Keldor
+permalink: /projects/frostgrave/starting-sorcerer
 
 ---
 


### PR DESCRIPTION
## Summary
- use a unique permalink for the "Starting Sorcerer" page to prevent clashes with the Keldor page

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a7e2b59a70832bbf78b7e540bdc153