### PR TITLE
Parse header image count as integer

### DIFF
--- a/assets/js/beautifuljekyll.js
+++ b/assets/js/beautifuljekyll.js
@@ -50,7 +50,7 @@ let BeautifulJekyllJS = {
     // If the page was large images to randomly select from, choose an image
     if ($("#header-big-imgs").length > 0) {
       BeautifulJekyllJS.bigImgEl = $("#header-big-imgs");
-      BeautifulJekyllJS.numImgs = BeautifulJekyllJS.bigImgEl.attr("data-num-img");
+      BeautifulJekyllJS.numImgs = parseInt(BeautifulJekyllJS.bigImgEl.attr("data-num-img"), 10);
 
       // 2fc73a3a967e97599c9763d05e564189
       // set an initial image


### PR DESCRIPTION
## Summary
- Parse `data-num-img` attribute as an integer for header image rotation.
- Ensure subsequent image rotation logic uses numeric comparisons and math.

## Testing
- `bundle exec jekyll build`
- Manual jsdom test of header rotation logic

------
https://chatgpt.com/codex/tasks/task_e_68a7e41a90a4832b844a0e726b261a6d