### PR TITLE
fix: use latest ruby setup action

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
## Summary
- update ruby/setup-ruby action to v1 in Jekyll workflow

## Testing
- `bundle check`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a7e7069190832b98bcc4175e5bb3e5