### PR TITLE
Add fallback for legacy image paths

### DIFF
--- a/_includes/img.html
+++ b/_includes/img.html
@@ -9,5 +9,7 @@
 {%- assign src = include.src -%}
 {%- if src | slice: 0, 12 == '/assets/img/' -%}
   {%- assign src = src | remove_first: '/assets/img/' -%}
+  {% picture {{ preset }} {{ src | jsonify }} --alt {{ alt | jsonify }}{{ extra }} %}
+{%- else -%}
+  <img src="{{ src | relative_url }}" alt="{{ alt }}"{% unless classes == '' %} class="{{ classes }}"{% endunless %}>
 {%- endif -%}
-{% picture {{ preset }} {{ src | jsonify }} --alt {{ alt | jsonify }}{{ extra }} %}


### PR DESCRIPTION
## Summary
- Render legacy images with a basic `<img>` tag when they aren't part of the new pipeline
- Preserve jekyll_picture_tag for images in `assets/img`

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68ac89a093ec832bb233ddb22bb2f35f