### PR TITLE
Remove jekyll_picture_tag plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "csv"
 gem "base64"
 gem "jekyll-paginate"
 gem "jekyll-sitemap"
-gem 'jekyll_picture_tag'
 gem 'kramdown-parser-gfm'
 gem 'webrick'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,13 +57,6 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    jekyll_picture_tag (2.1.3)
-      addressable (~> 2.6)
-      jekyll (~> 4.0)
-      mime-types (~> 3.0)
-      objective_elements (~> 1.1)
-      rainbow (~> 3.0)
-      ruby-vips (~> 2.2)
     json (2.13.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
@@ -73,26 +66,16 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.7.0)
     mercenary (0.4.0)
-    mime-types (3.7.0)
-      logger
-      mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0819)
-    objective_elements (1.1.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.2)
-    rainbow (3.1.1)
     rake (13.3.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.1)
     rouge (4.6.0)
-    ruby-vips (2.2.5)
-      ffi (~> 1.12)
-      logger
     rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass-embedded (1.90.0-x64-mingw-ucrt)
@@ -106,7 +89,6 @@ GEM
     tzinfo-data (1.2023.4)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.6.0)
-    wdm (0.2.0)
     webrick (1.9.1)
 
 PLATFORMS
@@ -121,11 +103,9 @@ DEPENDENCIES
   jekyll-paginate
   jekyll-remote-theme
   jekyll-sitemap
-  jekyll_picture_tag
   kramdown-parser-gfm
   tzinfo (= 2.0.6)
   tzinfo-data (= 1.2023.4)
-  wdm (>= 0.1.0)
   webrick
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -320,12 +320,7 @@ plugins:
   - jekyll-paginate
   - jekyll-sitemap
   - jekyll-remote-theme
-  - jekyll_picture_tag
-
-picture:
-  source: assets/img
-  output: assets/generated
-
+  
 # Beautiful Jekyll / Dean Attali
 # 2fc73a3a967e97599c9763d05e564189
 

--- a/_includes/img.html
+++ b/_includes/img.html
@@ -1,15 +1,8 @@
-{%- assign preset = include.preset | default: 'default' -%}
 {%- assign alt = include.alt | default: '' -%}
 {%- capture img_class -%}
 {%- if include.border -%}img-border{%- endif -%}
 {%- if include.class -%}{% if include.border %} {% endif %}{{ include.class }}{%- endif -%}
 {%- endcapture -%}
 {%- assign classes = img_class | strip -%}
-{%- capture extra -%}{% unless classes == '' %} --img class="{{ classes }}"{% endunless %}{%- endcapture -%}
 {%- assign src = include.src -%}
-{%- if src | slice: 0, 12 == '/assets/img/' -%}
-  {%- assign src = src | remove_first: '/assets/img/' -%}
-  {% picture {{ preset }} {{ src | jsonify }} --alt {{ alt | jsonify }}{{ extra }} %}
-{%- else -%}
-  <img src="{{ src | relative_url }}" alt="{{ alt }}"{% unless classes == '' %} class="{{ classes }}"{% endunless %}>
-{%- endif -%}
+<img src="{{ src | relative_url }}" alt="{{ alt }}"{% unless classes == '' %} class="{{ classes }}"{% endunless %}>


### PR DESCRIPTION
## Summary
- drop `jekyll_picture_tag` dependency and configuration
- swap image include to render plain `<img>` tags

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68ad31456a48832bbb1a3c616abc3f2b