### PR TITLE
Use categories field across site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Use these optional keys in posts, projects, or features to integrate with the ma
 ```
 cover: /assets/covers/<file>.jpg
 featured: true
-category: FPV
+categories: FPV
 # or
 # tags: [FPV]
 ```
 
 Items marked `featured: true` appear in the homepage's featured section.
-`category` or `tags` are used to populate topic sections.
+`categories` or `tags` are used to populate topic sections.
 
 ## Development
 

--- a/_config.yml
+++ b/_config.yml
@@ -296,13 +296,13 @@ jekyll_compose:
     drafts:
       title: 
       cover-img:
-      category:
+      categories:
       tags:
       layout: "post"
     posts:
       title: 
       cover-img:
-      category:
+      categories:
       tags:
       readtime: true
       layout: "post"

--- a/_drafts/back-again.md
+++ b/_drafts/back-again.md
@@ -2,7 +2,7 @@
 layout: post
 title: Back Again
 cover-img:
-category: blog
+categories: blog
 tags: blog, update, news
 ---
 

--- a/_drafts/back-again.md.backup
+++ b/_drafts/back-again.md.backup
@@ -3,7 +3,7 @@
 layout: post
 title: Back Again
 cover-img:
-category: blog
+categories: blog
 tags: blog,, update, news
 
 ---

--- a/_drafts/long-ass-week.md
+++ b/_drafts/long-ass-week.md
@@ -3,7 +3,7 @@
 layout: post
 title: Time Fly's
 cover-img:
-category:
+categories:
 tags: blog, update,life,irl
 
 ---

--- a/_drafts/march-by.md
+++ b/_drafts/march-by.md
@@ -4,7 +4,7 @@ layout: post
 title: March On By
 cover-img:  "/assets/img/march-on/bust_wip_header.jpg"
 thumbnail-img: "/assets/img/march-on/march-on-thumb.jpg"
-category: Blog, Update
+categories: [Blog, Update]
 tags: minis, blog, painting, gaming
 
 ---

--- a/_drafts/more-of-the-same.md
+++ b/_drafts/more-of-the-same.md
@@ -2,6 +2,6 @@
 layout: post
 title:
 cover-img:
-category:
+categories:
 tags:
 ---

--- a/_drafts/sept-3-8.md
+++ b/_drafts/sept-3-8.md
@@ -3,7 +3,7 @@
 layout: post
 title: Weekly Blog
 cover-img:
-category:
+categories:
 tags: [blog,post,update,September]
 
 ---

--- a/_posts/2024-02-12-miner.md
+++ b/_posts/2024-02-12-miner.md
@@ -2,7 +2,7 @@
 layout: post
 title: First Entry
 cover-img: "/assets/img/miner/DG-Thumb.jpg"
-category:
+categories:
 - OPR
 tags:
 - painting

--- a/_posts/2024-09-03-falling-into-line.md
+++ b/_posts/2024-09-03-falling-into-line.md
@@ -2,7 +2,7 @@
 layout: post
 title: Falling In
 cover-img:
-category: Blog
+categories: Blog
 tags:
 - blog
 - post

--- a/_projects/Frostgrave.md
+++ b/_projects/Frostgrave.md
@@ -26,7 +26,7 @@ After a year of, if I'm honest, farting around, I finally found the focus and or
 
 <!-- Post list for Frostgrave category -->
 <ul class="posts-list list-unstyled" role="list">
-{% assign frostgrave_posts = site.posts | where: "category", "Frostgrave" %}
+{% assign frostgrave_posts = site.posts | where: "categories", "Frostgrave" %}
 {% for post in frostgrave_posts %}
   <li class="post-preview">
     <article>

--- a/_projects/frostgrave-lore/Keldor.md
+++ b/_projects/frostgrave-lore/Keldor.md
@@ -3,7 +3,7 @@ layout: project
 title: Keldor Of Darrik
 subtitle: Frostgrave warband lore
 permalink: /projects/frostgrave/Keldor
-category: Frostgrave, Lore
+categories: [Frostgrave, Lore]
 tags: [Frostgrave, lore, writing, homebrew, fantasy]
 
 ---

--- a/_projects/one-page-rules.md
+++ b/_projects/one-page-rules.md
@@ -10,7 +10,7 @@ I've got a good bit of a Dwarven Guild list printed and painted, and I'm excited
 
 <!-- Post list for One Page Rules category -->
 <ul class="posts-list list-unstyled" role="list">
-{% assign opr_posts = site.posts | where: "category", "OPR" %}
+{% assign opr_posts = site.posts | where: "categories", "OPR" %}
 {% for post in opr_posts %}
   <li class="post-preview">
     <article>

--- a/_projects/warhammer40k.md
+++ b/_projects/warhammer40k.md
@@ -12,7 +12,7 @@ Details about the Warhammer 40K project. Here you can add a brief description or
 
 <!-- Post list for Warhammer 40K category -->
 <ul class="posts-list list-unstyled" role="list">
-{% assign wh40k_posts = site.posts | where: "category", "Warhammer 40K" %}
+{% assign wh40k_posts = site.posts | where: "categories", "Warhammer 40K" %}
 {% for post in wh40k_posts %}
   <li class="post-preview">
     <article>


### PR DESCRIPTION
## Summary
- Rename post front matter from `category` to `categories`
- Update project templates to filter posts by `categories`
- Switch Jekyll Compose defaults and README docs to `categories`

## Testing
- `bundle install`
- `PAGES_REPO_NWO=prairiepilotfpv/prairiepilotfpv.github.io bundle exec jekyll build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ce56110832b85b25abdaad04cc5